### PR TITLE
Configuración de aplicación para el despliegue en Heroku

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -441,4 +441,7 @@ module.exports = function (grunt) {
     'test',
     'build'
   ]);
+
+  // Tarea destinada al despliegue en Heroku
+  grunt.registerTask('heroku', ['build']);
 };

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node web.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {},
   "repository": {},
   "devDependencies": {
+    "express": "^4.12.4",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^2.0.0",
     "grunt-concurrent": "^1.0.0",
@@ -25,6 +26,7 @@
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",
+    "gzippo": "^0.2.0",
     "jshint-stylish": "^1.0.0",
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",

--- a/web.js
+++ b/web.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var gzippo = require('gzippo');
+var express = require('express');
+var logger = require('morgan');
+var nodeApp = express();
+
+nodeApp.use(logger('dev'));
+nodeApp.use(gzippo.staticGzip('' + __dirname + '/dist'));
+nodeApp.listen(process.env.PORT || 5000);


### PR DESCRIPTION
Estos cambios tienen por objetivo el poder **desplegar exitosamente la aplicación en Heroku**, para un futuro *despliegue automático* luego de cada cambio. Para esto, se ha hecho uso del [**buildpack Yo Angular**](https://github.com/nknj/heroku-buildpack-yo-angular) de Heroku.

Generalmente, los tutoriales y documentación referida al despliegue en Heroku de aplicaciones AngularJS hacen uso de **añadir la carpeta ```dist``` al control de versionado**, para que sea servida estáticamente por Heroku. Un ejemplo de este método puede encontrarse en [Deploying a Yeoman/Angular app to Heroku](http://www.sitepoint.com/deploying-yeomanangular-app-heroku/). Sin embargo, los archivos de este directorio no deberían ser agregados al repositorio, ya que **son archivos generados** y todo cambio mediante PRs produciría inconsistencias en los mismos.

El uso del buildpack de Heroku mencionado resuelve esto, al permitir que **la aplicación sea generada** mediante ```grunt build``` **directamente en el servidor**, manteniendo limpio el repositorio y facilitando la integración de PRs.

Los cambios aquí introducidos son los mismos que se explican en el ```README``` del repositorio del buildpack **Yo Angular**. Como síntesis, el sentido de los cambios en cada archivo es el siguiente:

* ```Gruntfile```: Se añade una tarea específica para el despliegue en Heroku, que ejecuta ```grunt build```.
* ```Procfile```: Indica el comando a ejecutar por el servidor web que corra la aplicación en Heroku. En este caso, levanta un servidor Node.js y ejecuta el contenido del archivo nuevo ```web.js```.
* ```package.json```: Añade como dependencias los módulos que utiliza ```web.js```: *express* y *gzippo*.
* ```web.js```: Especifica el código a ser ejecutado por el servidor Node.js, y que tiene por finalidad servir el contenido del sitio, ya generado por ```grunt```.

Si bien probé los cambios y funciona correctamente, **necesita ser testeado** y que confirmen que funciona antes de ser integrado.